### PR TITLE
clear session storage before redirecting to Spotify

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,13 +16,18 @@ const spotifyApi = new SpotifyWebApi({
 app.get("/login", (req, res) => {
   const scopes = [
     "streaming",
-    "user-modify-playback-state", // um den Browser zum aktuellen Gerät zu machen
+    "user-modify-playback-state",
     "user-read-currently-playing",
     "user-read-email",
     "user-read-private"
   ];
   const authUrl = spotifyApi.createAuthorizeURL(scopes);
-  res.redirect(authUrl);
+  res.send(`
+    <script>
+      sessionStorage.removeItem('playedTracks');
+      window.location.href = '${authUrl}';
+    </script>
+  `);
 });
 
 app.get("/callback", async (req, res) => {


### PR DESCRIPTION
[`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL19-R30): Modified the `/login` route to send a script that clears the `playedTracks` session storage item before redirecting to the Spotify authorization URL.